### PR TITLE
New image 2dii/pacta

### DIFF
--- a/pacta/Dockerfile
+++ b/pacta/Dockerfile
@@ -1,0 +1,9 @@
+FROM 2dii/r-packages:latest
+LABEL maintainer='Mauro Lepore'
+
+COPY PACTA_analysis /pacta/PACTA_analysis
+COPY create_interactive_report /pacta/create_interactive_report
+COPY pacta-data /pacta/pacta-data
+COPY StressTestingModelDev /pacta/StressTestingModelDev
+
+RUN exit 0

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -1,0 +1,12 @@
+Build this image from the parent directory of PACTA_analysis. You may
+copy this Dockerfile or link it, for example:
+
+```bash
+ln -sv Dockerfile ~/git/Dockerfile -f
+```
+
+Then build the image as usual, for example:
+
+```bash
+docker build . --tag 2dii/pacta:0.0.0.9000
+```

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -1,3 +1,17 @@
+# Description
+
+The Dockerfile in this directory creates an image containing a copy of your
+local repository PACTA_analysis and all the repositories it depends on. For
+it to work, all those repositories should be siblings (i.e. share the same
+parent directory), and they should also be siblings of this repository --
+2diidockerrunner.
+
+Before you build build this image you may want to pull from
+GitHub the latest changes of PACTA_analysis and friends (see
+https://github.com/maurolepore/bin/blob/master/pacta-sync).
+
+# Usage
+
 Build this image from this directory:
 
 ```bash
@@ -11,7 +25,6 @@ Build this image from this directory:
 Run a container from anywhere:
 
 ```bash
-# Run a container from the image 2dii/pacta:0.0.1, and destroy it on exit (--rm)
+# Run a container from 2dii/pacta:0.0.1, and destroy it on exit (--rm)
 docker run --rm -ti 2dii/pacta:latest /bin/bash
 ```
-

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -6,3 +6,9 @@ here is how I copy this Dockerfile, change directory, and build the image
 cp ~/git/2diidockerrunner/pacta/Dockerfile ~/git && cd ~/git && docker build . --tag 2dii/pacta:0.0.0.9000
 ```
 
+And this is how I run a temporary container:
+
+```bash
+git docker run --rm -ti 2dii/pacta:0.0.0.9000 /bin/bash
+```
+

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -25,6 +25,6 @@ Build this image from this directory:
 Run a container from anywhere:
 
 ```bash
-# Run a container from 2dii/pacta:0.0.1, and destroy it on exit (--rm)
+# Run a container from 2dii/pacta:latest and destroy it on exit (--rm)
 docker run --rm -ti 2dii/pacta:latest /bin/bash
 ```

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -1,12 +1,8 @@
-Build this image from the parent directory of PACTA_analysis. You may
-copy this Dockerfile or link it, for example:
+Build this image from the parent directory of PACTA_analysis. For example, 
+here is how I copy this Dockerfile, change directory, and build the image
+-- all in one step:
 
 ```bash
-ln -sv Dockerfile ~/git/Dockerfile -f
+cp ~/git/2diidockerrunner/pacta/Dockerfile ~/git && cd ~/git && docker build . --tag 2dii/pacta:0.0.0.9000
 ```
 
-Then build the image as usual, for example:
-
-```bash
-docker build . --tag 2dii/pacta:0.0.0.9000
-```

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -1,14 +1,17 @@
-Build this image from the parent directory of PACTA_analysis. For example, 
-here is how I copy this Dockerfile, change directory, and build the image
--- all in one step:
+Build this image from this directory:
 
 ```bash
-cp ~/git/2diidockerrunner/pacta/Dockerfile ~/git && cd ~/git && docker build . --tag 2dii/pacta:0.0.0.9000
+# Build 2dii/pacta:0.0.1
+./build-tag 0.0.1
+
+# Build 2dii/pacta:latest (default)
+./build-tag
 ```
 
-And this is how I run a temporary container:
+Run a container from anywhere:
 
 ```bash
-git docker run --rm -ti 2dii/pacta:0.0.0.9000 /bin/bash
+# Run a container from the image 2dii/pacta:0.0.1, and destroy it on exit (--rm)
+docker run --rm -ti 2dii/pacta:latest /bin/bash
 ```
 

--- a/pacta/build-tag
+++ b/pacta/build-tag
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+cp Dockerfile ../../
+docker build ../../ --tag 2dii/pacta:"${1:-latest}"


### PR DESCRIPTION
This PR adds an image that starts from 2dii/r-packages and adds a copy of the relevant "pacta repos". Unfortunately, it seems that the image must be built from a directory that is a parent (not sibling) of "pacta repos". I explain how to build it and run a container from it -- see [README.md](https://github.com/2DegreesInvesting/2diidockerrunner/tree/new-2dii-pacta/pacta).

TODO: We need to follow up with a PR to adapt the scripts in PACTA_analysis/bin/. As CJ noted earlier, those scripts expect the directory "/bound/" to exist in the container. Same goes for some code in the web_tool_scripts*.R (search for "bound").