### PR TITLE
Copy pacta repos under / (and use /bound)

### DIFF
--- a/pacta/Dockerfile
+++ b/pacta/Dockerfile
@@ -1,9 +1,9 @@
 FROM 2dii/r-packages:latest
 LABEL maintainer='Mauro Lepore'
 
-COPY PACTA_analysis /pacta/PACTA_analysis
-COPY create_interactive_report /pacta/create_interactive_report
-COPY pacta-data /pacta/pacta-data
-COPY StressTestingModelDev /pacta/StressTestingModelDev
+COPY PACTA_analysis /bound
+COPY create_interactive_report /create_interactive_report
+COPY pacta-data /pacta-data
+COPY StressTestingModelDev /StressTestingModelDev
 
 RUN exit 0

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -1,18 +1,25 @@
 # Description
 
 The Dockerfile in this directory creates an image containing a copy of your
-local repository PACTA_analysis and all the repositories it depends on. For
-it to work, all those repositories should be siblings (i.e. share the same
-parent directory), and they should also be siblings of this repository --
-2diidockerrunner.
+local repository PACTA_analysis and all the repositories it depends on.
 
-Before you build build this image you may want to pull from
-GitHub the latest changes of PACTA_analysis and friends (see
-https://github.com/maurolepore/bin/blob/master/pacta-sync).
+The tree of the docker container looks like this:
+
+```bash
+/bound  # contents of PACTA_analysis
+/pacta-data
+/create_interactive_report
+# ... more siblings of PACTA_analysis
+```
 
 # Usage
 
-Build this image from this directory:
+Before you build build this image you may want to pull from
+GitHub the latest changes of PACTA_analysis and friends (see
+<https://github.com/maurolepore/bin/blob/master/pacta-sync>).
+
+`build-tag` helps you build this image. You must run it from inside this
+directory:
 
 ```bash
 # Build 2dii/pacta:0.0.1
@@ -28,3 +35,21 @@ Run a container from anywhere:
 # Run a container from 2dii/pacta:latest and destroy it on exit (--rm)
 docker run --rm -ti 2dii/pacta:latest /bin/bash
 ```
+
+Once you start the container, change directory into /bound -- which is
+the name of PACTA_analysis in the container.
+
+```bash
+cd /bound
+```
+
+Now you may run the web-tool scripts only:
+
+```bash
+./bin/run-web-tool-from-local-copy
+```
+
+Note that PACTA_analysis and friends are not mounted but copied into the
+conainer, so they will be frozen in the state they are when you build
+the image.
+

--- a/system/Dockerfile
+++ b/system/Dockerfile
@@ -10,6 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime && \
     dpkg-reconfigure --frontend noninteractive tzdata && \
     apt-get -y install \
+       git \
        build-essential \
        r-base \
        texlive-luatex \


### PR DESCRIPTION
Depends on https://github.com/2DegreesInvesting/PACTA_analysis/pull/311
Depends on https://github.com/2DegreesInvesting/PACTA_analysis/pull/312

This PR changes the image 2dii/pacta to copy the pacta repos under the root, 
and names PACTA_analysis as /bound. This is more backward compatible. 
The instructions in pacta/README.md will work pending on the issues above.