### PR TITLE
Show the sha of HEAD only once

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -13,13 +13,6 @@ done
 
 for repo in ${clones}
 do
-    echo "${repo} HEAD sha:"
-    git -C "${repo}" rev-parse HEAD
-    echo "--"
-done
-
-for repo in ${clones}
-do
     git -C "${repo}" tag -a "${tag}" -m "Release pacta ${tag}" HEAD
     echo "${repo}"
     echo "$(git -C ${repo} log --pretty='%h %d <%an> (%cr)' | head -n 1)"


### PR DESCRIPTION
This commit removes duplicated information: The sha of the HEAD is
shown right after the code I remove here (along with the commit
message, author, time since last commit).

Feel free to ignore if the duplicatoin is intentional.
