### PR TITLE
New clone_and_status removes duplication

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -64,7 +64,7 @@ echo
 docker build --tag 2dii_pacta:"$tag" --tag 2dii_pacta:latest .
 echo
 
-for repo in $clones
+for repo in $repos
 do
     rm -rf "$repo"
 done

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -41,13 +41,13 @@ clone_and_log () {
     for repo in $repos
     do
         remote="${url}${repo}.git"
-        git clone -b master "$remote" --depth 1 || exit 0
+        git clone -b master "$remote" --depth 1 || exit 2
         echo
 
         if [ -n "$tag" ]
         then
             echo "Tagging as $tag"
-            git -C "$repo" tag -a "$tag" -m "Release pacta $tag" HEAD || exit 0
+            git -C "$repo" tag -a "$tag" -m "Release pacta $tag" HEAD || exit 2
             echo
         fi
 

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -4,27 +4,27 @@ tag="${1:-latest}"
 url="git@github.com:2DegreesInvesting/"
 
 clone_and_log () {
-for repo in ${clones}
-do
-    remote="${url}${repo}.git"
-    git clone -b master ${remote} --depth 1
-    echo "--"
-done
+    for repo in ${clones}
+    do
+        remote="${url}${repo}.git"
+        git clone -b master ${remote} --depth 1
+        echo "--"
+    done
 
-for repo in ${clones}
-do
-    echo "${repo} HEAD sha:"
-    git -C "${repo}" rev-parse HEAD
-    echo "--"
-done
+    for repo in ${clones}
+    do
+        echo "${repo} HEAD sha:"
+        git -C "${repo}" rev-parse HEAD
+        echo "--"
+    done
 
-for repo in ${clones}
-do
-    git -C "${repo}" tag -a "${tag}" -m "Release pacta ${tag}" HEAD
-    echo "${repo}"
-    echo "$(git -C ${repo} log --pretty='%h %d <%an> (%cr)' | head -n 1)"
-    echo "--"
-done
+    for repo in ${clones}
+    do
+        git -C "${repo}" tag -a "${tag}" -m "Release pacta ${tag}" HEAD
+        echo "${repo}"
+        echo "$(git -C ${repo} log --pretty='%h %d <%an> (%cr)' | head -n 1)"
+        echo "--"
+    done
 }
 
 clones="${2:-PACTA_analysis create_interactive_report StressTestingModelDev pacta-data}"

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -27,14 +27,14 @@ fi
 if [ -z "$tag" ]
 then
     echo "Please give a tag."
-    exit 0
+    exit 2
 fi
 
 here="$(basename $(pwd))"
 if [ ! "$here" == "pacta" ]
 then
     echo "Please run from 2diidockerrunner/pacta (not $(pwd))"
-    exit 0
+    exit 2
 fi
 
 clone_and_log () {

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -1,9 +1,9 @@
 #! /bin/bash
 
 tag="${1:-latest}"
-clones="${2:-PACTA_analysis create_interactive_report StressTestingModelDev pacta-data}"
 url="git@github.com:2DegreesInvesting/"
 
+clone_and_log () {
 for repo in ${clones}
 do
     remote="${url}${repo}.git"
@@ -25,6 +25,10 @@ do
     echo "$(git -C ${repo} log --pretty='%h %d <%an> (%cr)' | head -n 1)"
     echo "--"
 done
+}
+
+clones="${2:-PACTA_analysis create_interactive_report StressTestingModelDev pacta-data}"
+clone_and_log
 
 docker rmi --force $(docker images -q '2dii_pacta' | uniq)
 docker build --tag 2dii_pacta:"${tag}" --tag 2dii_pacta:latest .
@@ -36,9 +40,8 @@ done
 
 unzip pacta_web_template.zip
 
-git clone -b master "${url}"user_results.git --depth 1
-echo "user_results HEAD sha:"
-git -C user_results rev-parse HEAD
+clones="user_results"
+clone_and_log
 
 needless_files=".git .gitignore .DS_Store README.md user_results.Rproj"
 for file in ${needless_files}

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -1,13 +1,29 @@
 #! /bin/bash
 
 # Examples:
+# # The tag is enforced
 # build_with_tag 0.0.0.999
+#
+# # Optionally give the names of the repos as trailing arguments
+# build_with_tag 0.0.0.999 PACTA_analysis StressTestingModelDev
+#
+# # With the help of pacta-find, you don't need to know the names
+# # of pacta siblings -- it's enough to know the path to the parent.
+# pacta_siblings="$(basename $(pacta-find ~/git))"
+# ./build_with_tag.sh 0.0.0.999 "$pacta_siblings"
+#
+# # You may want to cleanup, particularly if the process ends early.
+# git clean -dffx
 
-repos="PACTA_analysis create_interactive_report StressTestingModelDev pacta-data"
 user_results="user_results"
 url="git@github.com:2DegreesInvesting/"
-
 tag="$1"
+repos="${@:2}"
+if [ -z "$repos" ]
+then
+    repos="PACTA_analysis create_interactive_report StressTestingModelDev pacta-data"
+fi
+
 if [ -z "$tag" ]
 then
     echo "Please give a tag."

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -13,13 +13,6 @@ clone_and_log () {
 
     for repo in ${clones}
     do
-        echo "${repo} HEAD sha:"
-        git -C "${repo}" rev-parse HEAD
-        echo "--"
-    done
-
-    for repo in ${clones}
-    do
         git -C "${repo}" tag -a "${tag}" -m "Release pacta ${tag}" HEAD
         echo "${repo}"
         echo "$(git -C ${repo} log --pretty='%h %d <%an> (%cr)' | head -n 1)"


### PR DESCRIPTION
This PR adds `clone_and_log` that we can use with 'user_results' separately from other repos -- to keep the processes separate without duplicating code. 

This DRYer approach helps the script evolve faster and safer as we now need to update code in only one place.