### PR TITLE
Quiet zip/unzip/gzip

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -69,7 +69,9 @@ do
     rm -rf "$repo"
 done
 
-unzip pacta_web_template.zip
+web_template_zip="pacta_web_template.zip"
+echo "Unzipping $web_template_zip ..."
+unzip -q "$web_template_zip"
 echo
 
 repos="$user_results"
@@ -85,10 +87,14 @@ done
 cp -R user_results/ pacta_web/user_results/4/
 rm -rf user_results
 
-docker save 2dii_pacta | gzip > pacta_web/2dii_pacta.tar.gz
+image_tar_gz="pacta_web/2dii_pacta.tar.gz"
+echo "Saving 2dii_pacta into $image_tar_gz ..."
+docker save 2dii_pacta | gzip -q > "$image_tar_gz"
 echo
 
-zip -r pacta_web.zip pacta_web -x ".DS_Store" -x "__MACOSX"
+web_zip="pacta_web.zip"
+echo "Zipping $web_zip ..."
+zip -rq "$web_zip" pacta_web -x ".DS_Store" -x "__MACOSX"
 
 rm -rf pacta_web
 


### PR DESCRIPTION
This pr quiets the output of zip, unzip, and gzip, which
seems uninteresting and obscures more useful messages.

The last part of the output is now this:

```
Unzipping pacta_web_template.zip ...

Cloning into 'user_results'...
remote: Enumerating objects: 71, done.
remote: Counting objects: 100% (71/71), done.
remote: Compressing objects: 100% (57/57), done.
remote: Total 71 (delta 23), reused 55 (delta 14), pack-reused 0
Receiving objects: 100% (71/71), 5.38 MiB | 1.02 MiB/s, done.
Resolving deltas: 100% (23/23), done.

529618c  (grafted, HEAD -> master, tag: 0.0.1, origin/master, origin/HEAD) <Monika Furdyna> (6 days ago)

Saving 2dii_pacta into pacta_web/2dii_pacta.tar.gz ...

Zipping pacta_web.zip ...
Done
```﻿
