### PR TITLE
We can now build from anywhere

### DIFF
--- a/pacta/README.md
+++ b/pacta/README.md
@@ -38,8 +38,7 @@ which will
   - make some necessary permissions changes
   - an export of the freshly made docker image gzipped (2dii_pacta.tar.gz)
 
-If the build is succesful, one should test it with the test scripts, and if
-the tests are successful, load the image interactively and push the tags
+If the build is succesful, load the image interactively and push the tags
 created for each of the PACTA_analysis and friends repos inside of the
 docker container.
 

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -20,7 +20,9 @@ the image.
 
 # Usage
 
-Run the build_with_tag.sh script from this directory, specifying a tag to assign to it. Ideally the tag should use semantic versioning, and should follow previously existing tags in the PACTA_analysis and friends repos.
+Run the build_with_tag.sh script from anywhere, specifying a tag to assign
+to it. Ideally the tag should use semantic versioning, and should follow
+previously existing tags in the PACTA_analysis and friends repos.
 
 ```bash
 ./build_with_tag.sh 0.0.4
@@ -29,24 +31,28 @@ Run the build_with_tag.sh script from this directory, specifying a tag to assign
 The script will:
 - clone the repos locally, only copying the current version of the files
 - remove any existing "2dii_pacta" images from your local docker system
-- build a "2dii_pacta" docker image using the Dockerfile in this directory, which will
+- build a "2dii_pacta" docker image using the Dockerfile in this directory,
+which will
   - use 2dii/r-packages as a base
   - copy in the frshly cloned repos
   - make some necessary permissions changes
-- use pacta_web_template.zip as a template to create new zip file named pacta_web.zip in this directory which will contain
   - an export of the freshly made docker image gzipped (2dii_pacta.tar.gz)
-  - a few scripts and directories that contain sample data to facilitate testing the new image
 
-If the build is succesful, one should test it with the test scripts, and if the tests are successful, load the image interactively and push the tags created for each of the PACTA_analysis and friends repos inside of the docker container.
+If the build is succesful, one should test it with the test scripts, and if
+the tests are successful, load the image interactively and push the tags
+created for each of the PACTA_analysis and friends repos inside of the
+docker container.
 
 
 # For the web
 
 
 That shared docker image can be loaded into the new machine with...
+
 ```docker load --input 2dii_pacta.tar.gz```
 
 The docker image can then be used as intended with a script such as...
+
 ```
 working_dir="$(pwd)"/working_dir
 user_results="$(pwd)"/user_results
@@ -57,4 +63,9 @@ docker run --rm -ti \
   2dii_pacta \
   /bound/bin/run-r-scripts
 ```
-where you set `working_dir` to the path to the directory that contains the user specific portfolio info on the server, and you set `user_results` to the path to the directory that contains the survey (and other) results that are relevant to the specific user on the server. Those directories will then be mounted inside of the docker containter in the appropriate locations.
+
+where you set `working_dir` to the path to the directory that contains the
+user specific portfolio info on the server, and you set `user_results` to
+the path to the directory that contains the survey (and other) results that
+are relevant to the specific user on the server. Those directories will then
+be mounted inside of the docker containter in the appropriate locations.

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -20,7 +20,7 @@ the image.
 
 # Usage
 
-Run the build_with_tag.sh script from anywhere, specifying a tag to assign
+Run the build_with_tag.sh script, specifying a tag to assign
 to it. Ideally the tag should use semantic versioning, and should follow
 previously existing tags in the PACTA_analysis and friends repos.
 

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -36,7 +36,7 @@ which will
   - use 2dii/r-packages as a base
   - copy in the freshly cloned repos
   - make some necessary permissions changes
-  - an export of the freshly made docker image gzipped (2dii_pacta.tar.gz)
+  - export the freshly made docker image gzipped (2dii_pacta.tar.gz)
 
 If the build is succesful, load the image interactively and push the tags
 created for each of the PACTA_analysis and friends repos inside of the

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -34,7 +34,7 @@ The script will:
 - build a "2dii_pacta" docker image using the Dockerfile in this directory,
 which will
   - use 2dii/r-packages as a base
-  - copy in the frshly cloned repos
+  - copy in the freshly cloned repos
   - make some necessary permissions changes
   - an export of the freshly made docker image gzipped (2dii_pacta.tar.gz)
 

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -29,10 +29,12 @@ previously existing tags in the PACTA_analysis and friends repos.
 ```
 
 The script will:
+
 - clone the repos locally, only copying the current version of the files
 - remove any existing "2dii_pacta" images from your local docker system
-- build a "2dii_pacta" docker image using the Dockerfile in this directory,
-which will
+- build a "2dii_pacta:<tag>" and "2dii_pacta:latest" docker image (where <tag>
+is the tag you provided, e.g. 0.0.4). The image builds from the Dockerfile
+in this directory, which will
   - use 2dii/r-packages as a base
   - copy in the freshly cloned repos
   - make some necessary permissions changes

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -15,7 +15,7 @@ The tree of the docker container looks like this:
 # Usage
 
 Note that PACTA_analysis and friends are not mounted but copied into the
-conainer, so they will be frozen in the state they are when you build
+container, so they will be frozen in the state they are when you build
 the image.
 
 # Usage
@@ -40,7 +40,7 @@ in this directory, which will
   - make some necessary permissions changes
   - export the freshly made docker image gzipped (2dii_pacta.tar.gz)
 
-If the build is succesful, load the image interactively and push the tags
+If the build is successful, load the image interactively and push the tags
 created for each of the PACTA_analysis and friends repos inside of the
 docker container.
 
@@ -69,4 +69,4 @@ where you set `working_dir` to the path to the directory that contains the
 user specific portfolio info on the server, and you set `user_results` to
 the path to the directory that contains the survey (and other) results that
 are relevant to the specific user on the server. Those directories will then
-be mounted inside of the docker containter in the appropriate locations.
+be mounted inside of the docker container in the appropriate locations.

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -38,20 +38,13 @@ then
     exit 2
 fi
 
-here="$(basename $(pwd))"
-if [ ! "$here" == "pacta" ]
-then
-    red "Please run from 2diidockerrunner/pacta (not $(pwd))."
-    exit 2
-fi
-
 for repo in $repos
 do
     # Clone
     remote="${url}${repo}.git"
     git clone -b master "$remote" --depth 1 || exit 2
     echo
-    
+
     # Tag
     if [ -n "$tag" ]
     then
@@ -76,7 +69,8 @@ do
     rm -rf "$repo"
 done
 
-image_tar_gz="2dii_pacta.tar.gz"
+parent="$(dirname $(which $0))"
+image_tar_gz="${parent}/2dii_pacta.tar.gz"
 green "Saving 2dii_pacta into $image_tar_gz ..."
 docker save 2dii_pacta | gzip -q > "$image_tar_gz"
 echo

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -38,13 +38,6 @@ then
     exit 2
 fi
 
-here="$(basename $(pwd))"
-if [ ! "$here" == "pacta" ]
-then
-    red "Please run from 2diidockerrunner/pacta (not $(pwd))."
-    exit 2
-fi
-
 for repo in $repos
 do
     # Clone

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -44,7 +44,7 @@ do
     remote="${url}${repo}.git"
     git clone -b master "$remote" --depth 1 || exit 2
     echo
-    
+
     # Tag
     if [ -n "$tag" ]
     then
@@ -69,7 +69,8 @@ do
     rm -rf "$repo"
 done
 
-image_tar_gz="2dii_pacta.tar.gz"
+parent="$(dirname $(which $0))"
+image_tar_gz="${parent}/2dii_pacta.tar.gz"
 green "Saving 2dii_pacta into $image_tar_gz ..."
 docker save 2dii_pacta | gzip -q > "$image_tar_gz"
 echo


### PR DESCRIPTION
This commit makes the command portable: we can call it from anywhere.
The location of the command is used to find the Dockerfile and to
output the image's .tar.gz file.

I also updated README to reflect the changes (plus a lil style -- happy to submit separately if neede).